### PR TITLE
delete func tests

### DIFF
--- a/src/trees/splay_tree_test.go
+++ b/src/trees/splay_tree_test.go
@@ -16,6 +16,18 @@ func initializeSmallCompleteTree() (*SplayTree, int32) {
 	return tree, lastElement
 }
 
+func initializeSmallTree2() *SplayTree {
+	tree := NewSplayTree(10)
+	tree.Insert(5)
+	tree.Insert(15)
+	tree.Insert(3)
+	tree.Insert(8)
+	tree.Insert(12)
+	tree.Insert(20)
+	tree.Insert(1)
+	return tree
+}
+
 func initializeMediumTree() *SplayTree {
 	tree := NewSplayTree(10)
 	tree.Insert(5)
@@ -167,4 +179,15 @@ func TestSplayTree_TreeToList(t *testing.T) {
 	if values[6] != 3 {
 		t.Errorf("Expected 3, got %d", values[1])
 	}
+}
+
+func TestSplayTree_Delete_Small_1(t *testing.T) {
+	tree, _ := initializeSmallCompleteTree()
+	tree.BreadthFirstPrint()
+}
+
+func TestNewSplayTree_Delete_Small_2(t *testing.T) {
+	tree := initializeSmallTree2()
+	tree.Delete(12)
+	tree.BreadthFirstPrint()
 }

--- a/src/trees/splay_trees.go
+++ b/src/trees/splay_trees.go
@@ -1,5 +1,7 @@
 package trees
 
+import "fmt"
+
 type Node struct {
 	Data       int32
 	LeftChild  *Node
@@ -225,30 +227,34 @@ func (tree *SplayTree) Delete(val int32) {
 	rightSubtree := new(SplayTree)
 	rightSubtree.Root = x.RightChild
 
-	//delete x
-	if parent.LeftChild == x {
-		parent.LeftChild = nil
-	} else {
-		parent.RightChild = nil
+	//delete x and splay the tree on x's parent
+	if parent != nil {
+		if parent.LeftChild == x {
+			parent.LeftChild = nil
+		} else {
+			parent.RightChild = nil
+		}
 	}
-	//setting x's children to nil
-	x.LeftChild, x.RightChild = nil, nil
 
+	//splaying left subtree then attaching the right to it
 	leftMax := findMaxNode(leftSubtree.Root)
 	leftSubtree.splay(leftMax)
-	tree.splay(parent)
-
 	leftSubtree.Root.RightChild = rightSubtree.Root
 
-	if leftMax.Data < parent.Data {
-		parent.LeftChild = leftMax
-	} else {
-		parent.RightChild = leftMax
+	if parent != nil {
+		if leftMax.Data < parent.Data {
+			parent.LeftChild = leftMax
+		} else {
+			parent.RightChild = leftMax
+		}
 	}
+
+	tree.splay(parent)
 
 	//ensuring GC
 	leftSubtree = nil
 	rightSubtree = nil
+	x.LeftChild, x.RightChild = nil, nil
 }
 
 // finds the node holding the element to delete, and nil if the element is not in the tree
@@ -296,6 +302,31 @@ func (tree *SplayTree) ToList() []int32 {
 			queue = append(queue, node.RightChild)
 		}
 	}
-
 	return values
+}
+
+func (tree *SplayTree) BreadthFirstPrint() {
+	if tree == nil || tree.Root == nil {
+		panic(NullPointerError)
+	}
+
+	var queueCapacity int32 = 0
+	queue := make([]*Node, 0)
+
+	queue = append(queue, tree.Root)
+	queueCapacity++
+
+	for queueCapacity > 0 {
+		if queue[0].LeftChild != nil {
+			queue = append(queue, queue[0].LeftChild)
+			queueCapacity++
+		}
+		if queue[0].RightChild != nil {
+			queue = append(queue, queue[0].RightChild)
+			queueCapacity++
+		}
+		fmt.Println(queue[0].Data)
+		queue = queue[1:]
+		queueCapacity--
+	}
 }


### PR DESCRIPTION
fixed bug in the delete func where we were splaying the deleted node's parent before attaching the splayed left subtree+right subtree  also added 1 more test